### PR TITLE
Feat/ml phase1

### DIFF
--- a/app/src/main/java/io/pm/finlight/data/db/dao/SmsParseTemplateDao.kt
+++ b/app/src/main/java/io/pm/finlight/data/db/dao/SmsParseTemplateDao.kt
@@ -1,0 +1,34 @@
+// =================================================================================
+// FILE: ./app/src/main/java/io/pm/finlight/data/db/dao/SmsParseTemplateDao.kt
+// REASON: NEW FILE - This DAO provides the necessary methods to interact with
+// the new `sms_parse_templates` table. It includes methods to insert new
+// templates and retrieve all existing templates for the heuristic engine to analyze.
+// =================================================================================
+package io.pm.finlight
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+/**
+ * Data Access Object (DAO) for the SmsParseTemplate entity.
+ */
+@Dao
+interface SmsParseTemplateDao {
+    /**
+     * Inserts a new template. If a template with the same signature already exists,
+     * the insertion is ignored to avoid duplicates.
+     * @param template The template to insert.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(template: SmsParseTemplate)
+
+    /**
+     * Retrieves all stored SMS parse templates.
+     * This is used by the heuristic engine to find a potential match for a new SMS.
+     * @return A list of all SmsParseTemplate objects.
+     */
+    @Query("SELECT * FROM sms_parse_templates")
+    suspend fun getAllTemplates(): List<SmsParseTemplate>
+}

--- a/app/src/main/java/io/pm/finlight/data/db/entity/SmsParseTemplate.kt
+++ b/app/src/main/java/io/pm/finlight/data/db/entity/SmsParseTemplate.kt
@@ -1,0 +1,44 @@
+// =================================================================================
+// FILE: ./app/src/main/java/io/pm/finlight/data/db/entity/SmsParseTemplate.kt
+// REASON: NEW FILE - This entity stores learned SMS patterns. When a user
+// corrects a parsed transaction, a template is created from the original SMS,
+// storing the structure and location of key data points. This allows the new
+// heuristic engine to parse similar, previously unknown SMS formats.
+// =================================================================================
+package io.pm.finlight
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Represents a learned SMS parsing template.
+ *
+ * This entity is created when a user manually corrects a transaction that was
+ * originally parsed from an SMS. It stores the structure of that SMS, allowing
+ * the heuristic engine to parse similar messages in the future.
+ *
+ * @param id The unique identifier for the template.
+ * @param templateSignature A normalized, simplified version of the SMS body used for efficient initial lookups.
+ * @param originalSmsBody The full, unmodified body of the source SMS.
+ * @param originalMerchantStartIndex The starting index of the merchant name in the originalSmsBody.
+ * @param originalMerchantEndIndex The ending index of the merchant name in the originalSmsBody.
+ * @param originalAmountStartIndex The starting index of the amount in the originalSmsBody.
+ * @param originalAmountEndIndex The ending index of the amount in the originalSmsBody.
+ */
+@Entity(
+    tableName = "sms_parse_templates",
+    indices = [Index(value = ["templateSignature"])]
+)
+data class SmsParseTemplate(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    @ColumnInfo(index = true)
+    val templateSignature: String,
+    val originalSmsBody: String,
+    val originalMerchantStartIndex: Int,
+    val originalMerchantEndIndex: Int,
+    val originalAmountStartIndex: Int,
+    val originalAmountEndIndex: Int
+)

--- a/app/src/main/java/io/pm/finlight/data/db/entity/SmsParseTemplate.kt
+++ b/app/src/main/java/io/pm/finlight/data/db/entity/SmsParseTemplate.kt
@@ -1,9 +1,9 @@
 // =================================================================================
 // FILE: ./app/src/main/java/io/pm/finlight/data/db/entity/SmsParseTemplate.kt
-// REASON: NEW FILE - This entity stores learned SMS patterns. When a user
-// corrects a parsed transaction, a template is created from the original SMS,
-// storing the structure and location of key data points. This allows the new
-// heuristic engine to parse similar, previously unknown SMS formats.
+// REASON: FIX - Removed the redundant `index = true` property from the
+// `templateSignature` ColumnInfo. The index is already explicitly defined in the
+// @Entity annotation, and having both was causing a KSP build error due to a
+// duplicate index name.
 // =================================================================================
 package io.pm.finlight
 
@@ -34,7 +34,8 @@ import androidx.room.PrimaryKey
 data class SmsParseTemplate(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
-    @ColumnInfo(index = true)
+    // --- FIX: Removed `index = true` as it's redundant with the @Entity index ---
+    @ColumnInfo
     val templateSignature: String,
     val originalSmsBody: String,
     val originalMerchantStartIndex: Int,

--- a/app/src/main/java/io/pm/finlight/receiver/SmsReceiver.kt
+++ b/app/src/main/java/io/pm/finlight/receiver/SmsReceiver.kt
@@ -1,8 +1,11 @@
 // =================================================================================
 // FILE: ./app/src/main/java/io/pm/finlight/receiver/SmsReceiver.kt
-// REASON: REFACTOR - Updated to use the decoupled SmsParser from the 'core'
-// module. It now instantiates and passes data provider implementations
-// (which wrap the DAOs) to the parser, adhering to the new architecture.
+// REASON: FEATURE - The receiver now implements the heuristic parsing engine.
+// If the primary `SmsParser` fails, it fetches all learned `SmsParseTemplate`s
+// from the database. It then uses a Levenshtein distance algorithm to find the
+// most structurally similar template. If a high-confidence match is found, it
+// applies the template's known data positions to extract the merchant and amount
+// from the new SMS, enabling the app to parse previously unknown formats.
 // =================================================================================
 package io.pm.finlight
 
@@ -24,6 +27,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.util.Date
+import kotlin.math.min
 
 class SmsReceiver : BroadcastReceiver() {
     private val tag = "SmsReceiver"
@@ -55,8 +59,7 @@ class SmsReceiver : BroadcastReceiver() {
 
                         val smsMessage = SmsMessage(id = smsId, sender = sender, body = fullBody, date = smsId)
 
-                        // --- REFACTOR: Use the decoupled SmsParser from the core module ---
-                        val potentialTxn = SmsParser.parse(
+                        var potentialTxn = SmsParser.parse(
                             sms = smsMessage,
                             mappings = existingMappings,
                             customSmsRuleProvider = object : CustomSmsRuleProvider {
@@ -72,6 +75,34 @@ class SmsReceiver : BroadcastReceiver() {
                                 override suspend fun getCategoryIdForMerchant(merchantName: String): Int? = db.merchantCategoryMappingDao().getCategoryIdForMerchant(merchantName)
                             }
                         )
+
+                        // --- NEW HEURISTIC FALLBACK LOGIC ---
+                        if (potentialTxn == null) {
+                            Log.d(tag, "Primary parser failed. Attempting heuristic match...")
+                            val smsParseTemplateDao = db.smsParseTemplateDao()
+                            val allTemplates = smsParseTemplateDao.getAllTemplates()
+
+                            if (allTemplates.isNotEmpty()) {
+                                val newSmsBody = smsMessage.body
+                                var bestMatch: SmsParseTemplate? = null
+                                var highestScore = 0.0
+
+                                for (template in allTemplates) {
+                                    val score = calculateSimilarity(newSmsBody, template.originalSmsBody)
+                                    if (score > highestScore) {
+                                        highestScore = score
+                                        bestMatch = template
+                                    }
+                                }
+
+                                val SIMILARITY_THRESHOLD = 0.85 // 85% similar
+                                if (bestMatch != null && highestScore >= SIMILARITY_THRESHOLD) {
+                                    Log.d(tag, "Found heuristic match with score $highestScore. Template ID: ${bestMatch.id}")
+                                    potentialTxn = applyTemplate(newSmsBody, bestMatch, smsMessage)
+                                }
+                            }
+                        }
+
 
                         if (potentialTxn != null && !existingSmsHashes.contains(potentialTxn.sourceSmsHash)) {
 
@@ -175,5 +206,81 @@ class SmsReceiver : BroadcastReceiver() {
         } else {
             Log.e(tag, "Failed to find or create an account for the transaction.")
         }
+    }
+
+    // --- NEW HELPER FUNCTIONS FOR HEURISTIC PARSING ---
+
+    private fun applyTemplate(newSmsBody: String, template: SmsParseTemplate, originalSms: SmsMessage): PotentialTransaction? {
+        try {
+            // Extract merchant and amount based on stored indices, with bounds checking
+            val merchant = newSmsBody.substring(
+                template.originalMerchantStartIndex,
+                min(template.originalMerchantEndIndex, newSmsBody.length)
+            )
+            val amountStr = newSmsBody.substring(
+                template.originalAmountStartIndex,
+                min(template.originalAmountEndIndex, newSmsBody.length)
+            )
+            val amount = amountStr.replace(",", "").toDoubleOrNull() ?: return null
+
+            val transactionType = when {
+                SmsParser.EXPENSE_KEYWORDS_REGEX.containsMatchIn(template.originalSmsBody) -> "expense"
+                SmsParser.INCOME_KEYWORDS_REGEX.containsMatchIn(template.originalSmsBody) -> "income"
+                else -> return null
+            }
+
+            val potentialAccount = SmsParser.parseAccount(newSmsBody, originalSms.sender)
+            val smsHash = (originalSms.sender.filter { it.isDigit() }.takeLast(10) + newSmsBody).hashCode().toString()
+            val smsSignature = SmsParser.generateSmsSignature(newSmsBody)
+
+            return PotentialTransaction(
+                sourceSmsId = originalSms.id,
+                smsSender = originalSms.sender,
+                amount = amount,
+                transactionType = transactionType,
+                merchantName = merchant,
+                originalMessage = newSmsBody,
+                potentialAccount = potentialAccount,
+                sourceSmsHash = smsHash,
+                smsSignature = smsSignature,
+                date = originalSms.date
+            )
+        } catch (e: Exception) {
+            Log.e("SmsReceiver", "Error applying heuristic template", e)
+            return null
+        }
+    }
+
+    private fun calculateSimilarity(s1: String, s2: String): Double {
+        val longer = if (s1.length > s2.length) s1 else s2
+        val shorter = if (s1.length > s2.length) s2 else s1
+        if (longer.isEmpty()) return 1.0
+        val distance = levenshteinDistance(longer, shorter)
+        return (longer.length - distance) / longer.length.toDouble()
+    }
+
+    private fun levenshteinDistance(s1: String, s2: String): Int {
+        val costs = IntArray(s2.length + 1)
+        for (i in 0..s1.length) {
+            var lastValue = i
+            for (j in 0..s2.length) {
+                if (i == 0) {
+                    costs[j] = j
+                } else {
+                    if (j > 0) {
+                        var newValue = costs[j - 1]
+                        if (s1[i - 1] != s2[j - 1]) {
+                            newValue = min(min(newValue, lastValue), costs[j]) + 1
+                        }
+                        costs[j - 1] = lastValue
+                        lastValue = newValue
+                    }
+                }
+            }
+            if (i > 0) {
+                costs[s2.length] = lastValue
+            }
+        }
+        return costs[s2.length]
     }
 }

--- a/core/src/main/java/io/pm/finlight/core/SmsParser.kt
+++ b/core/src/main/java/io/pm/finlight/core/SmsParser.kt
@@ -1,10 +1,9 @@
 // =================================================================================
 // FILE: ./core/src/main/java/io/pm/finlight/core/SmsParser.kt
 // REASON: FIX - Changed the visibility of several helper properties and functions
-// (e.g., EXPENSE_KEYWORDS_REGEX, parseAccount) from `private` to `internal`.
-// This makes them accessible to other modules within the project, such as the
-// :app module, resolving the "Cannot access" build errors in SmsReceiver and
-// TransactionViewModel.
+// (e.g., EXPENSE_KEYWORDS_REGEX, parseAccount) from `internal` to `public`. This
+// makes them accessible across modules, resolving the "Cannot access" build
+// errors in SmsReceiver.
 // =================================================================================
 package io.pm.finlight
 
@@ -20,8 +19,8 @@ sealed class ParseResult {
 object SmsParser {
     private val AMOUNT_WITH_HIGH_CONFIDENCE_KEYWORDS_REGEX = "(?:debited by|spent|debited for|credited with|sent|tranx of|transferred from|debited with)\\s+(?:(INR|RS|USD|SGD|MYR|EUR|GBP)[:.]?\\s*)?([\\d,]+\\.?\\d*)|(?:Rs|INR)[:.]?\\s*([\\d,]+\\.?\\d*)".toRegex(RegexOption.IGNORE_CASE)
     private val FALLBACK_AMOUNT_REGEX = "([\\d,]+\\.?\\d*)(INR|RS|USD|SGD|MYR|EUR|GBP)|(?:\\b(INR|RS|USD|SGD|MYR|EUR|GBP)(?![a-zA-Z])[ .]*)?([\\d,]+\\.?\\d*)|([\\d,]+\\.?\\d*)\\s*(?:\\b(INR|RS|USD|SGD|MYR|EUR|GBP)\\b)".toRegex(RegexOption.IGNORE_CASE)
-    internal val EXPENSE_KEYWORDS_REGEX = "\\b(spent|debited|paid|charged|debit instruction for|tranx of|deducted for|sent to|sent|withdrawn|DEBIT with amount|spent on|purchase of|transferred from|frm|debited by|has a debit by transfer of|without OTP/PIN|successfully debited with|was spent from|Deducted!?|Dr with)\\b".toRegex(RegexOption.IGNORE_CASE)
-    internal val INCOME_KEYWORDS_REGEX = "\\b(credited|received|deposited|refund of|added|credited with salary of|reversal of transaction|unsuccessful and will be reversed|loaded with|has credit for|CREDIT with amount|CREDITED to your account|has a credit|has been CREDITED to your|is Credited for|We have credited)\\b".toRegex(RegexOption.IGNORE_CASE)
+    val EXPENSE_KEYWORDS_REGEX = "\\b(spent|debited|paid|charged|debit instruction for|tranx of|deducted for|sent to|sent|withdrawn|DEBIT with amount|spent on|purchase of|transferred from|frm|debited by|has a debit by transfer of|without OTP/PIN|successfully debited with|was spent from|Deducted!?|Dr with)\\b".toRegex(RegexOption.IGNORE_CASE)
+    val INCOME_KEYWORDS_REGEX = "\\b(credited|received|deposited|refund of|added|credited with salary of|reversal of transaction|unsuccessful and will be reversed|loaded with|has credit for|CREDIT with amount|CREDITED to your account|has a credit|has been CREDITED to your|is Credited for|We have credited)\\b".toRegex(RegexOption.IGNORE_CASE)
 
     private val ACCOUNT_PATTERNS =
         listOf(
@@ -319,7 +318,7 @@ object SmsParser {
         return ParseResult.Success(transaction)
     }
 
-    internal fun generateSmsSignature(body: String): String {
+    fun generateSmsSignature(body: String): String {
         var signature = body.lowercase()
         VOLATILE_DATA_REGEX.forEach { regex ->
             signature = regex.replace(signature, "")
@@ -327,7 +326,7 @@ object SmsParser {
         return signature.replace(Regex("\\s+"), " ").trim().hashCode().toString()
     }
 
-    internal fun parseAccount(smsBody: String, sender: String): PotentialAccount? {
+    fun parseAccount(smsBody: String, sender: String): PotentialAccount? {
         for (pattern in ACCOUNT_PATTERNS) {
             val match = pattern.find(smsBody)
             if (match != null) {

--- a/core/src/main/java/io/pm/finlight/core/SmsParser.kt
+++ b/core/src/main/java/io/pm/finlight/core/SmsParser.kt
@@ -21,7 +21,7 @@ object SmsParser {
     private val AMOUNT_WITH_HIGH_CONFIDENCE_KEYWORDS_REGEX = "(?:debited by|spent|debited for|credited with|sent|tranx of|transferred from|debited with)\\s+(?:(INR|RS|USD|SGD|MYR|EUR|GBP)[:.]?\\s*)?([\\d,]+\\.?\\d*)|(?:Rs|INR)[:.]?\\s*([\\d,]+\\.?\\d*)".toRegex(RegexOption.IGNORE_CASE)
     private val FALLBACK_AMOUNT_REGEX = "([\\d,]+\\.?\\d*)(INR|RS|USD|SGD|MYR|EUR|GBP)|(?:\\b(INR|RS|USD|SGD|MYR|EUR|GBP)(?![a-zA-Z])[ .]*)?([\\d,]+\\.?\\d*)|([\\d,]+\\.?\\d*)\\s*(?:\\b(INR|RS|USD|SGD|MYR|EUR|GBP)\\b)".toRegex(RegexOption.IGNORE_CASE)
     // --- UPDATED: Added "debit" to the list of expense keywords ---
-    val EXPENSE_KEYWORDS_REGEX = "\\b(spent|debited|paid|charged|debit instruction for|tranx of|deducted for|sent to|sent|withdrawn|DEBIT with amount|spent on|purchase of|transferred from|frm|debited by|has a debit by transfer of|without OTP/PIN|successfully debited with|was spent from|Deducted!?|Dr with|debit of)\\b".toRegex(RegexOption.IGNORE_CASE)
+    val EXPENSE_KEYWORDS_REGEX = "\\b(spent|debited|paid|charged|debit instruction for|tranx of|deducted for|sent to|sent|withdrawn|DEBIT with amount|spent on|purchase of|transferred from|frm|debited by|has a debit by transfer of|without OTP/PIN|successfully debited with|was spent from|Deducted!?|Dr with|debit of)\\b|transaction has been recorded".toRegex(RegexOption.IGNORE_CASE)
     val INCOME_KEYWORDS_REGEX = "\\b(credited|received|deposited|refund of|added|credited with salary of|reversal of transaction|unsuccessful and will be reversed|loaded with|has credit for|CREDIT with amount|CREDITED to your account|has a credit|has been CREDITED to your|is Credited for|We have credited)\\b".toRegex(RegexOption.IGNORE_CASE)
 
     private val ACCOUNT_PATTERNS =


### PR DESCRIPTION
Created a new Room entity and DAO for SmsParseTemplate to store the original SMS body, the generated template, and the positions of the placeholders.
[cite_start]Hooked into the TransactionViewModel's updateTransactionDescription function to trigger this template generation logic. [cite: 43, 85]
[cite_start]Updated the SmsReceiver to add this heuristic check as a fallback step after the primary regex engine fails to find a match. [cite: 1515-1529]